### PR TITLE
fix: array_chunks removed from nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,8 +115,8 @@ default = ["std"]
 # are enabled, so we can benchmark them.
 bench = []
 
-# The `nightly` feature enables nightly-only features like `array_chunks` and
-# `portable_simd`. This is automatically enabled if the compiler is nightly.
+# The `nightly` feature enables nightly-only features like `portable_simd`.
+# This is automatically enabled if the compiler is nightly.
 nightly = []
 
 # The `std` feature enables the use of the standard library. This is useful for

--- a/src/implementation/simd.rs
+++ b/src/implementation/simd.rs
@@ -9,8 +9,8 @@ pub fn contains_null_or_utf8_4_byte_char_header(value: &[u8]) -> bool {
 
     macro_rules! process {
         ($simd:ty) => {
-            let array_chunks = remainder.array_chunks::<{ <$simd>::LEN }>();
-            remainder = array_chunks.remainder();
+            let (array_chunks, array_remainder) = remainder.as_chunks::<{ <$simd>::LEN }>();
+            remainder = array_remainder;
 
             let zero = <$simd>::splat(0x00);
             let mask = <$simd>::splat(0b1111_1000);
@@ -43,8 +43,8 @@ pub fn contains_utf8_4_byte_char_header(value: &[u8]) -> bool {
 
     macro_rules! process {
         ($simd:ty) => {
-            let array_chunks = remainder.array_chunks::<{ <$simd>::LEN }>();
-            remainder = array_chunks.remainder();
+            let (array_chunks, array_remainder) = remainder.as_chunks::<{ <$simd>::LEN }>();
+            remainder = array_remainder;
 
             let mask = <$simd>::splat(0b1111_1000);
             let header = <$simd>::splat(0b1111_0000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("README.md")]
-#![cfg_attr(
-    feature = "nightly",
-    feature(array_chunks, portable_simd, error_in_core)
-)]
+#![cfg_attr(feature = "nightly", feature(portable_simd, error_in_core))]
 // NOTE: We use this to prevent false positives when using the nightly
 // toolchain.
 #![cfg_attr(feature = "nightly", allow(stable_features))]


### PR DESCRIPTION
<!-- Before making a PR, please read my contributing guidelines https://github.com/seancroach/.github/blob/main/CONTRIBUTING.md -->

The latest Rust nightly (`nightly-2025-07-30`) removed `std::slice::ArrayChunks`.
The suggested alternative is `slice::as_chunks`, which returns both a slice of arrays as well as the remainder.

Here is the relevant PR: rust-lang/rust#&NoBreak;143289

| Q                         | A <!--(Can use an emoji 👍) -->
| ------------------------- | -----
| Fixed Issues?             | ❌
| Patch: Bug fix?           | 👍
| Minor: New feature?       | ❌
| Major: Breaking change?   | ❌
| Any dependency changes?   | ❌

<!-- Describe your changes below in as much detail as possible -->

Replaced both usages of `array_chunks` with `as_chunks`, removed the feature, and adjusted the docs.