### PR TITLE
feat: encode_into

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -198,8 +198,8 @@ fn decode_code_point(code_point: u32) -> [u8; 4] {
     ]
 }
 
-/// Encodes a string into a vector of bytes using the given flavor of encoding:
-/// CESU-8 or MUTF-8.
+/// Encodes a string into a new vector of bytes using the given flavor of
+/// encoding: CESU-8 or MUTF-8.
 ///
 /// NOTE: This function is inlined. It is expected that the call site of this
 /// function is **not** inlined. This is to ensure that LLVM elides the flavor
@@ -213,8 +213,27 @@ fn decode_code_point(code_point: u32) -> [u8; 4] {
 #[must_use]
 #[inline]
 pub(crate) fn encode(value: &str, flavor: Flavor) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_into(value, flavor, &mut buf);
+    buf
+}
+
+/// Encodes a string into an existing vector of bytes using the given flavor of
+/// encoding: CESU-8 or MUTF-8.
+///
+/// NOTE: This function is inlined. It is expected that the call site of this
+/// function is **not** inlined. This is to ensure that LLVM elides the flavor
+/// logic when the flavor is known at compile time.
+///
+/// # Panics
+///
+/// If `value` is greater than <code>[isize::MAX] / 2</code> bytes long, this
+/// function might panic by trying to allocate a vector with a capacity greater
+/// than [`isize::MAX`] bytes.
+#[inline]
+pub(crate) fn encode_into(value: &str, flavor: Flavor, buf: &mut Vec<u8>) {
     let capacity = value.len().checked_mul(2).unwrap_or(ISIZE_MAX_USIZE);
-    let mut encoded = Vec::with_capacity(capacity);
+    buf.reserve(capacity);
 
     let bytes = value.as_bytes();
     let mut index = 0;
@@ -229,9 +248,9 @@ pub(crate) fn encode(value: &str, flavor: Flavor) -> Vec<u8> {
         // improved performance by over 80%.
         if first <= 0x7f {
             if flavor == Flavor::Mutf8 && first == 0x00 {
-                encoded.extend_from_slice(&[0xc0, 0x80]);
+                buf.extend_from_slice(&[0xc0, 0x80]);
             } else {
-                encoded.push(first);
+                buf.push(first);
             }
 
             index += 1;
@@ -239,13 +258,13 @@ pub(crate) fn encode(value: &str, flavor: Flavor) -> Vec<u8> {
             // SAFETY: We know that `bytes` is a valid UTF-8 string, so the
             // slice is guaranteed to be valid.
             let slice = unsafe { bytes.get_unchecked(index..index + 2) };
-            encoded.extend_from_slice(slice);
+            buf.extend_from_slice(slice);
             index += 2;
         } else if first <= 0xef {
             // SAFETY: We know that `bytes` is a valid UTF-8 string, so the
             // slice is guaranteed to be valid.
             let slice = unsafe { bytes.get_unchecked(index..index + 3) };
-            encoded.extend_from_slice(slice);
+            buf.extend_from_slice(slice);
             index += 3;
         } else {
             // SAFETY: We know that `bytes` is a valid UTF-8 string, so the
@@ -263,13 +282,11 @@ pub(crate) fn encode(value: &str, flavor: Flavor) -> Vec<u8> {
                 | u32::from(fourth & 0b0011_1111);
 
             let [s1, s2] = to_surrogate_pair(code_point);
-            encoded.extend_from_slice(&encode_surrogate(s1));
-            encoded.extend_from_slice(&encode_surrogate(s2));
+            buf.extend_from_slice(&encode_surrogate(s1));
+            buf.extend_from_slice(&encode_surrogate(s2));
             index += 4;
         }
     }
-
-    encoded
 }
 
 #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,69 @@ pub fn encode(value: &str) -> Cow<'_, [u8]> {
     }
 }
 
+/// Encodes a string to CESU-8 into a provided vector of bytes.
+///
+/// The algorithm is as follows:
+///
+/// - If the input, as UTF-8, is also valid CESU-8, the function will copy the
+///   input into the buffer.
+/// - If the input, as UTF-8, is not valid CESU-8, the function will encode the
+///   input into the buffer. This case has the potential to panic.
+///
+/// # Panics
+///
+/// This function will panic if the total buffer, including any existing bytes,
+/// required to encode the input exceeds [`isize::MAX`] bytes.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate alloc;
+/// use alloc::borrow::Cow;
+///
+/// let mut buf = Vec::new();
+///
+/// let single_byte = "\u{0045}";
+/// assert_eq!(single_byte, "E");
+/// assert_eq!(single_byte.len(), 1);
+/// assert_eq!(single_byte.as_bytes(), &[0x45]);
+/// simd_cesu8::encode_into(single_byte, &mut buf);
+/// assert_eq!(&buf, &[0x45]);
+/// buf.clear();
+///
+/// let two_bytes = "\u{0205}";
+/// assert_eq!(two_bytes, "ȅ");
+/// assert_eq!(two_bytes.len(), 2);
+/// assert_eq!(two_bytes.as_bytes(), &[0xc8, 0x85]);
+/// simd_cesu8::encode_into(two_bytes, &mut buf);
+/// assert_eq!(&buf, &[0xc8, 0x85]);
+/// buf.clear();
+///
+/// let three_bytes = "\u{20ac}";
+/// assert_eq!(three_bytes, "€");
+/// assert_eq!(three_bytes.len(), 3);
+/// assert_eq!(three_bytes.as_bytes(), &[0xe2, 0x82, 0xac]);
+/// simd_cesu8::encode_into(three_bytes, &mut buf);
+/// assert_eq!(&three_bytes, &[0xe2, 0x82, 0xac]);
+/// buf.clear();
+///
+/// let four_bytes = "\u{10400}";
+/// assert_eq!(four_bytes, "𐐀");
+/// assert_eq!(four_bytes.len(), 4);
+/// assert_eq!(four_bytes.as_bytes(), &[0xf0, 0x90, 0x90, 0x80]);
+/// simd_cesu8::encode_into(four_bytes, &mut buf);
+/// assert_eq!(&four_bytes, &[0xed, 0xa0, 0x81, 0xed, 0xb0, 0x80]);
+/// buf.clear();
+/// ```
+#[inline]
+pub fn encode_into(value: &str, buf: &mut Vec<u8>) {
+    if needs_encoded(value) {
+        internal::encode_into(value, Flavor::Cesu8, buf);
+    } else {
+        buf.extend_from_slice(value.as_bytes());
+    }
+}
+
 /// Returns `true` if the input string needs to be encoded to CESU-8.
 ///
 /// # Examples


### PR DESCRIPTION
<!-- Before making a PR, please read my contributing guidelines https://github.com/seancroach/.github/blob/main/CONTRIBUTING.md -->

| Q                         | A <!--(Can use an emoji 👍) -->
| ------------------------- | -----
| Fixed Issues?             | Fixes #4 
| Patch: Bug fix?           | Feature
| Minor: New feature?       | Yes
| Major: Breaking change?   | No
| Any dependency changes?   | No

<!-- Describe your changes below in as much detail as possible -->
Adds a way to encode into existing `Vec<u8>`s, allowing for preallocation and reuse of buffers.